### PR TITLE
Add serial_cpp_INSTALL CMake option to disable install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(serial_cpp VERSION ${SERIAL_CPP_MAJOR_VERSION}.${SERIAL_CPP_MINOR_VERSIO
 # For historical reasons, the default library type is static, but shared is also supported
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 option(BUILD_TESTING "Build tests" OFF)
+option(serial_cpp_INSTALL "Enable generation of serial_cpp install targets" ON)
 
 # Default install locations
 include(GNUInstallDirs)
@@ -73,47 +74,49 @@ add_dependencies(serial_cpp_example ${PROJECT_NAME}::${PROJECT_NAME})
 target_link_libraries(serial_cpp_example ${PROJECT_NAME}::${PROJECT_NAME})
 
 ## Install library
-install(TARGETS ${PROJECT_NAME}
-    EXPORT ${PROJECT_NAME}Targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-## Install headers
-install(FILES include/serial_cpp/serial.h include/serial_cpp/v8stdint.h include/serial_cpp/serial_compat.h
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
-
-## Generate and install CMake config files
-include(CMakePackageConfigHelpers)
-
-set(SERIAL_CPP_CMAKE_FILES_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-install(EXPORT ${PROJECT_NAME}Targets
-        FILE ${PROJECT_NAME}Targets.cmake
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION "${SERIAL_CPP_CMAKE_FILES_INSTALL_DIR}"
-)
-
-configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-  INSTALL_DESTINATION "${SERIAL_CPP_CMAKE_FILES_INSTALL_DIR}"
-)
-
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    VERSION "${serial_cpp_VERSION}"
-    COMPATIBILITY AnyNewerVersion
-)
-
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-              "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    DESTINATION "${SERIAL_CPP_CMAKE_FILES_INSTALL_DIR}")
-
-
-## Install package.xml
-install(FILES package.xml
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
+if(serial_cpp_INSTALL)
+    install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+    
+    ## Install headers
+    install(FILES include/serial_cpp/serial.h include/serial_cpp/v8stdint.h include/serial_cpp/serial_compat.h
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+    
+    ## Generate and install CMake config files
+    include(CMakePackageConfigHelpers)
+    
+    set(SERIAL_CPP_CMAKE_FILES_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+    
+    install(EXPORT ${PROJECT_NAME}Targets
+            FILE ${PROJECT_NAME}Targets.cmake
+            NAMESPACE ${PROJECT_NAME}::
+            DESTINATION "${SERIAL_CPP_CMAKE_FILES_INSTALL_DIR}"
+    )
+    
+    configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+      "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+      INSTALL_DESTINATION "${SERIAL_CPP_CMAKE_FILES_INSTALL_DIR}"
+    )
+    
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        VERSION "${serial_cpp_VERSION}"
+        COMPATIBILITY AnyNewerVersion
+    )
+    
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION "${SERIAL_CPP_CMAKE_FILES_INSTALL_DIR}")
+    
+    
+    ## Install package.xml
+    install(FILES package.xml
+        DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}")
+endif()
 
 ## Tests
 include(CTest)

--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ target_link_libraries(<target> PRIVATE serial_cpp::serial_cpp)
 If you only need to use `serial_cpp` inside a given CMake project, it make sense to include it via the [CMake's `FetchContent` module](https://cmake.org/cmake/help/latest/module/FetchContent.html):
 
 ~~~cmake
+include(FetchContent)
 FetchContent_Declare(
   serial_cpp
   GIT_REPOSITORY https://github.com/ami-iit/serial_cpp.git
-  GIT_TAG        v1.3.0 # or use the tag or commit you prefer
+  GIT_TAG        v1.3.1 # or use the tag or commit you prefer
 )
 
 FetchContent_MakeAvailable(serial_cpp)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>serial_cpp</name>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <description>
     serial_cpp is a cross-platform, simple to use library for using serial ports on computers.
     This library provides a C++, object oriented interface for interacting with RS-232


### PR DESCRIPTION
This option is useful in case, when using `FetchContent`, you want to disable the install of `serial_cpp` library. Furthermore, I also fixed the docs on usage of `FetchContent` by adding a missing `include(FetchContent)`.