### PR TITLE
Do not add tests if project is included via add_subdirectory/FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ include(CTest)
 # Tests are enabled if BUILD_TESTING is enabled and PROJECT_IS_TOP_LEVEL is ON,
 # or if serial_cpp_FORCE_BUILD_TESTING is ON, so if you include the project
 # via FetchContent or add_subdirectory and if you want to compile tests, you
-# need to set serial_cpp_FORCE_BUILD_TESTING to ON
-if((BUILD_TESTING OR PROJECT_IS_TOP_LEVEL) serial_cpp_FORCE_BUILD_TESTING)
+# need to set both BUILD_TESTING and serial_cpp_FORCE_BUILD_TESTING to ON
+if(BUILD_TESTING OR (PROJECT_IS_TOP_LEVEL OR serial_cpp_FORCE_BUILD_TESTING))
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,17 @@ project(serial_cpp VERSION ${SERIAL_CPP_MAJOR_VERSION}.${SERIAL_CPP_MINOR_VERSIO
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 option(BUILD_TESTING "Build tests" OFF)
 option(serial_cpp_INSTALL "Enable generation of serial_cpp install targets" ON)
+option(serial_cpp_FORCE_BUILD_TESTING "Enable tests even if project is the project was included via add_subdirectory/FetchContent" OFF)
+
+# Detect if project is top level or not (fall back for CMake < 3.21)
+if(CMAKE_VERSION VERSION_LESS "3.21.0")
+    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+        set(PROJECT_IS_TOP_LEVEL ON)
+    else()
+        set(PROJECT_IS_TOP_LEVEL OFF)
+    endif()
+endif()
+
 
 # Default install locations
 include(GNUInstallDirs)
@@ -120,6 +131,10 @@ endif()
 
 ## Tests
 include(CTest)
-if(BUILD_TESTING)
+# Tests are enabled if BUILD_TESTING is enabled and PROJECT_IS_TOP_LEVEL is ON,
+# or if serial_cpp_FORCE_BUILD_TESTING is ON, so if you include the project
+# via FetchContent or add_subdirectory and if you want to compile tests, you
+# need to set serial_cpp_FORCE_BUILD_TESTING to ON
+if((BUILD_TESTING OR PROJECT_IS_TOP_LEVEL) serial_cpp_FORCE_BUILD_TESTING)
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,9 @@ project(serial_cpp VERSION ${SERIAL_CPP_MAJOR_VERSION}.${SERIAL_CPP_MINOR_VERSIO
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 option(BUILD_TESTING "Build tests" OFF)
 option(serial_cpp_INSTALL "Enable generation of serial_cpp install targets" ON)
+mark_as_advanced(serial_cpp_INSTALL)
 option(serial_cpp_FORCE_BUILD_TESTING "Enable tests even if project is the project was included via add_subdirectory/FetchContent" OFF)
+mark_as_advanced(serial_cpp_FORCE_BUILD_TESTING)
 
 # Detect if project is top level or not (fall back for CMake < 3.21)
 if(CMAKE_VERSION VERSION_LESS "3.21.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,8 @@ option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" OFF)
 option(BUILD_TESTING "Build tests" OFF)
 option(serial_cpp_INSTALL "Enable generation of serial_cpp install targets" ON)
 mark_as_advanced(serial_cpp_INSTALL)
-option(serial_cpp_FORCE_BUILD_TESTING "Enable tests even if project is the project was included via add_subdirectory/FetchContent" OFF)
-mark_as_advanced(serial_cpp_FORCE_BUILD_TESTING)
+option(serial_cpp_FORCE_RESPECT_BUILD_TESTING "If also BUILD_TESTING is ON, enable tests even if project was included via add_subdirectory/FetchContent" OFF)
+mark_as_advanced(serial_cpp_FORCE_RESPECT_BUILD_TESTING)
 
 # Detect if project is top level or not (fall back for CMake < 3.21)
 if(CMAKE_VERSION VERSION_LESS "3.21.0")
@@ -134,9 +134,9 @@ endif()
 ## Tests
 include(CTest)
 # Tests are enabled if BUILD_TESTING is enabled and PROJECT_IS_TOP_LEVEL is ON,
-# or if serial_cpp_FORCE_BUILD_TESTING is ON, so if you include the project
+# or if serial_cpp_FORCE_RESPECT_BUILD_TESTING is ON, so if you include the project
 # via FetchContent or add_subdirectory and if you want to compile tests, you
-# need to set both BUILD_TESTING and serial_cpp_FORCE_BUILD_TESTING to ON
-if(BUILD_TESTING OR (PROJECT_IS_TOP_LEVEL OR serial_cpp_FORCE_BUILD_TESTING))
+# need to set both BUILD_TESTING and serial_cpp_FORCE_RESPECT_BUILD_TESTING to ON
+if(BUILD_TESTING OR (PROJECT_IS_TOP_LEVEL OR serial_cpp_FORCE_RESPECT_BUILD_TESTING))
     add_subdirectory(tests)
 endif()

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>serial_cpp</name>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <description>
     serial_cpp is a cross-platform, simple to use library for using serial ports on computers.
     This library provides a C++, object oriented interface for interacting with RS-232


### PR DESCRIPTION
We had a failure in a project that included `serial_cpp` via `FetchContent`, as it started to enable `BUILD_TESTING`, and we experience the failure:

~~~
CMake Error at /home/runner/micromamba/envs/internalprojectenv/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
  Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR
  GTEST_MAIN_LIBRARY)
Call Stack (most recent call first):
  /home/runner/micromamba/envs/internalprojectenv/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:591 (_FPHSA_FAILURE_MESSAGE)
  /home/runner/micromamba/envs/internalprojectenv/share/cmake-4.0/Modules/FindGTest.cmake:273 (find_package_handle_standard_args)
  build/_deps/serial_cpp-src/tests/CMakeLists.txt:2 (find_package)
~~~

The additional dependency on GTest if one enable `BUILD_TESTING` definitely breaks [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).

A more user-friend behavior is to disable tests if `PROJECT_IS_TOP_LEVEL` is OFF, unless someone really needs them enabled, in that case the new advanced option `serial_cpp_FORCE_RESPECT_BUILD_TESTING` can be used to force them to be enabled even if `PROJECT_IS_TOP_LEVEL` is OFF.