### PR TITLE
Fix wrong OR to AND in BUILD_TESTING and PROJECT_IS_TOP_LEVEL logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,6 @@ include(CTest)
 # or if serial_cpp_FORCE_RESPECT_BUILD_TESTING is ON, so if you include the project
 # via FetchContent or add_subdirectory and if you want to compile tests, you
 # need to set both BUILD_TESTING and serial_cpp_FORCE_RESPECT_BUILD_TESTING to ON
-if(BUILD_TESTING OR (PROJECT_IS_TOP_LEVEL OR serial_cpp_FORCE_RESPECT_BUILD_TESTING))
+if(BUILD_TESTING AND (PROJECT_IS_TOP_LEVEL OR serial_cpp_FORCE_RESPECT_BUILD_TESTING))
     add_subdirectory(tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ include(FetchContent)
 FetchContent_Declare(
   serial_cpp
   GIT_REPOSITORY https://github.com/ami-iit/serial_cpp.git
-  GIT_TAG        v1.3.2 # or use the tag or commit you prefer
+  GIT_TAG        v1.3.3 # or use the tag or commit you prefer
 )
 
 FetchContent_MakeAvailable(serial_cpp)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>serial_cpp</name>
-  <version>1.3.2</version>
+  <version>1.3.3</version>
   <description>
     serial_cpp is a cross-platform, simple to use library for using serial ports on computers.
     This library provides a C++, object oriented interface for interacting with RS-232


### PR DESCRIPTION
This is a leftover from https://github.com/ami-iit/serial_cpp/pull/8, the tests should required `BUILD_TESTING` **and** PROJECT_IS_TOP_LEVEL to be `ON`, if we use the `OR` only `BUILD_TESTING` `ON` is sufficient to enable tests, and so the logic is useless.