### PR TITLE
Fix arithmetic warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ doc/html
 ipch
 Debug
 Release
+.idea/
 
 # pixi environments
 .pixi

--- a/src/impl/unix.cc
+++ b/src/impl/unix.cc
@@ -455,7 +455,7 @@ Serial::SerialImpl::reconfigurePort ()
   // Compensate for the stopbits_one_point_five enum being equal to int 3,
   // and not 1.5.
   if (stopbits_ == stopbits_one_point_five) {
-    byte_time_ns_ += ((1.5 - stopbits_one_point_five) * bit_time_ns);
+    byte_time_ns_ += (1.5 - static_cast<double>(stopbits_one_point_five)) * bit_time_ns;
   }
 }
 


### PR DESCRIPTION
Fixes an arithmetic warning between double and enum. Deprecated in C++ 20 and this will fail in C++ 26