### PR TITLE
Add compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Alternatively, in case you do not want to modify all your code from  `serial::` 
 
 * Change the `#include <serial/serial.h>` inclusion to `#include <serial_cpp/serial_compat.h>`
 
+### Compatibility Policy
+
+This project tries to avoid removing functionalities in minor releases, while functionalities are only removed in major version. However, this is only done in a best-effort way, and it may be possible that backward incompatibly changes occur in minor releases (see [EffVer](https://jacobtomlinson.dev/effver/) for more details). Furthermore, the policy is that patch releases does not modify at all the public headers (i.e. the installed `.h` and `.hpp`) files of the project. This is done to ensure that no ABI change will occur in patch releases, without having to manually track ABI changes.
+
 ### License
 
 [The MIT License](LICENSE)


### PR DESCRIPTION
In a nutshell, that means that API is break only on major releases, while ABI may be break on minor releases, while patch releases are ABI-compatible. This will help fix https://github.com/ami-iit/serial_cpp/issues/14 .