### PR TITLE
Add Virtual COM port support on Windows

### DIFF
--- a/src/impl/list_ports/list_ports_win.cc
+++ b/src/impl/list_ports/list_ports_win.cc
@@ -38,10 +38,10 @@ serial_cpp::list_ports()
 	vector<PortInfo> devices_found;
 
 	HDEVINFO device_info_set = SetupDiGetClassDevs(
-		(const GUID *) &GUID_DEVCLASS_PORTS,
+		(const GUID *) &GUID_DEVINTERFACE_COMPORT,
 		NULL,
 		NULL,
-		DIGCF_PRESENT);
+		DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
 
 	unsigned int device_info_set_index = 0;
 	SP_DEVINFO_DATA device_info_data;

--- a/src/impl/list_ports/list_ports_win.cc
+++ b/src/impl/list_ports/list_ports_win.cc
@@ -10,6 +10,7 @@
 #include "serial_cpp/serial.h"
 #include <tchar.h>
 #include <windows.h>
+#include <winioctl.h>
 #include <setupapi.h>
 #include <initguid.h>
 #include <devguid.h>


### PR DESCRIPTION
Fixes https://github.com/wjwwood/serial/issues/202
I changed the `ClassGuid` to `GUID_DEVINTERFACE_COMPORT` as suggested in the issue which resolved the problem, I'm now able to see my virtual COM ports. I wasn't able to test this with physical COM ports, since my machine doesn't have any.